### PR TITLE
ci: Add fedora 38

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,6 +19,7 @@ jobs:
         distro:
           - fedora-36
           - fedora-37
+          - fedora-38
           - rockylinux-8
         repository: [throttled]
     env:


### PR DESCRIPTION
Adding Fedora 38 to the build list.
I also created a PR for the rpmbuilder image, such that this should work: https://github.com/abn/rpmbuilder/pull/6