### PR TITLE
ci: Add support for fedora 39

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,6 +19,7 @@ jobs:
         distro:
           - fedora-37
           - fedora-38
+          - fedora-39
           - rockylinux-8
         repository: [throttled]
     env:


### PR DESCRIPTION
Extends the ci to provide a build for fedora 39.